### PR TITLE
Feat/namespace-opt-in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,14 @@ jobs:
           go mod tidy
           go vet ./...
           make test
+          gotestsum --junitfile=tmp/test-results/junit.xml --format=standard-verbose -- -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: coverage.txt
+          path: coverage.out
 
       - name: Upload coverage report
         if: always()
@@ -41,3 +42,14 @@ jobs:
         with:
           name: junit.xml
           path: tmp/test-results/junit.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+            token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ go.work
 *.swp
 *.swo
 *~
+
+tmp/**

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
           - dupl
           - lll
           - errcheck
+          - unparam
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMG ?= quay.io/ullbergm/object-lease-controller:latest
 
 run: build
-	./bin/lease-controller -group startpunkt.ullberg.us -kind Application -version v1alpha2 -leader-elect -leader-elect-namespace default
+	./bin/lease-controller -group startpunkt.ullberg.us -kind Application -version v1alpha2 -leader-elect -leader-elect-namespace default -opt-in-label-key "object-lease-controller.ullberg.us/enabled" -opt-in-label-value true
 
 tidy:
 	go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ vet:
 	go vet ./...
 
 test: tidy fmt vet
-	go test ./... -timeout 30s
+	go test ./... -race -coverprofile=coverage.out
 
 build: tidy fmt vet test
 	go build -o bin/lease-controller ./cmd/main.go

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
+	github.com/go-logr/logr v1.4.2
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
 	k8s.io/client-go v0.33.0
@@ -19,7 +20,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/pkg/controllers/lease_controller.go
+++ b/pkg/controllers/lease_controller.go
@@ -99,8 +99,6 @@ func (r *LeaseWatcher) Reconcile(ctx context.Context, req controller_runtime.Req
 			log.Info("namespace not tracked, skipping", "namespace", req.Namespace)
 			return controller_runtime.Result{}, nil
 		}
-	} else {
-		log.Info("no namespace tracker configured, processing all namespaces")
 	}
 
 	obj := &unstructured.Unstructured{}

--- a/pkg/controllers/lease_controller.go
+++ b/pkg/controllers/lease_controller.go
@@ -1,4 +1,4 @@
-package leasewatcher
+package controllers
 
 import (
 	"context"
@@ -23,15 +23,17 @@ import (
 // Lease annotation keys
 const (
 	AnnTTL        = "object-lease-controller.ullberg.us/ttl"
-	AnnExtendedAt = "object-lease-controller.ullberg.us/extended-at"
+	AnnLeaseStart = "object-lease-controller.ullberg.us/lease-start" // RFC3339 UTC
 	AnnExpireAt   = "object-lease-controller.ullberg.us/expire-at"
 	AnnStatus     = "object-lease-controller.ullberg.us/lease-status"
 )
 
 type LeaseWatcher struct {
 	client.Client
-	GVK      schema.GroupVersionKind
-	Recorder record.EventRecorder
+	GVK       schema.GroupVersionKind
+	Tracker   *util.NamespaceTracker
+	Recorder  record.EventRecorder
+	eventChan chan util.NamespaceChangeEvent
 }
 
 var (
@@ -41,7 +43,7 @@ var (
 // Only trigger reconcile when relevant annotations change
 func leaseRelevantAnns(u *unstructured.Unstructured) map[string]string {
 	anns := u.GetAnnotations()
-	keys := []string{AnnTTL, AnnExtendedAt}
+	keys := []string{AnnTTL, AnnLeaseStart}
 	result := map[string]string{}
 	for _, k := range keys {
 		if v, ok := anns[k]; ok {
@@ -79,6 +81,24 @@ func (r *LeaseWatcher) Reconcile(ctx context.Context, req controller_runtime.Req
 	log := logger.FromContext(ctx).WithValues("GVK", r.GVK)
 	log.Info("reconciling lease")
 
+	// Filter by tracker namespaces
+	if r.Tracker != nil {
+		namespaces := r.Tracker.ListNamespaces()
+		found := false
+		for _, ns := range namespaces {
+			if req.Namespace == ns {
+				found = true
+				break
+			}
+		}
+		if !found {
+			log.Info("namespace not tracked, skipping", "namespace", req.Namespace)
+			return controller_runtime.Result{}, nil
+		}
+	} else {
+		log.Info("no namespace tracker configured, processing all namespaces")
+	}
+
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(r.GVK)
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
@@ -89,10 +109,16 @@ func (r *LeaseWatcher) Reconcile(ctx context.Context, req controller_runtime.Req
 		log.Error(err, "failed to get object")
 		return controller_runtime.Result{}, client.IgnoreNotFound(err)
 	}
+
 	anns := obj.GetAnnotations()
-	if anns == nil || anns[AnnTTL] == "" {
+	if anns == nil {
+		anns = map[string]string{}
+	}
+
+	// If TTL missing, clean up all lease annotations and return
+	if anns[AnnTTL] == "" {
 		cleaned := false
-		for _, k := range []string{AnnExpireAt, AnnStatus, AnnExtendedAt} {
+		for _, k := range []string{AnnExpireAt, AnnStatus, AnnLeaseStart} {
 			if _, exists := anns[k]; exists {
 				delete(anns, k)
 				cleaned = true
@@ -103,72 +129,47 @@ func (r *LeaseWatcher) Reconcile(ctx context.Context, req controller_runtime.Req
 			base := obj.DeepCopy()
 			obj.SetAnnotations(anns)
 			_ = r.Patch(ctx, obj, client.MergeFrom(base))
-
-			// Record the event
 			if r.Recorder != nil {
-				r.Recorder.Event(obj, "Normal", "LeaseAnnotationsCleaned", "Removed lease-related annotations as TTL is missing")
+				r.Recorder.Event(obj, "Normal", "LeaseAnnotationsCleaned", "Removed lease annotations because TTL is missing")
 			}
 		}
 		return controller_runtime.Result{}, nil
 	}
 
-	// Lease logic
-	var start time.Time
 	now := time.Now().UTC()
-	// Only set AnnExtendedAt if TTL is added after creation (i.e., object is not new and AnnExpireAt is missing)
-	ct := obj.GetCreationTimestamp()
-	isNew := ct.IsZero() || ct.UTC().Add(10*time.Second).After(now) // treat as new if just created (10s window)
-	if anns[AnnTTL] != "" && anns[AnnExpireAt] == "" && anns[AnnExtendedAt] == "" {
-		if !isNew {
-			log.Info("Lease TTL added after creation, setting extended-at", "name", obj.GetName())
-			anns[AnnExtendedAt] = now.Format(time.RFC3339)
-			r.updateAnnotations(ctx, obj, map[string]string{
-				AnnExtendedAt: anns[AnnExtendedAt],
-			})
-			start = now
 
-			// Record the event
-			if r.Recorder != nil {
-				r.Recorder.Event(obj, "Normal", "LeaseAdded", "Lease has been added to an existing object.")
-			}
-		} else {
-			// Record the event
-			if r.Recorder != nil {
-				r.Recorder.Event(obj, "Normal", "LeaseAdded", "Lease was added when the object was created.")
-			}
-		}
-	} else if ext, ok := anns[AnnExtendedAt]; ok && ext != "" {
-		t, err := time.Parse(time.RFC3339, ext)
-		if err == nil {
+	// Ensure lease-start exists. If missing or invalid, set to now.
+	start := now
+	if v, ok := anns[AnnLeaseStart]; ok && v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
 			start = t.UTC()
-		}
-
-		// Record the event
-		if r.Recorder != nil {
-			r.Recorder.Event(obj, "Normal", "LeaseExtended", "Lease was extended.")
-		}
-	}
-	if start.IsZero() {
-		if ct.IsZero() {
-			start = now
 		} else {
-			start = ct.UTC()
+			// reset invalid value
+			anns[AnnLeaseStart] = now.Format(time.RFC3339)
+			r.updateAnnotations(ctx, obj, map[string]string{AnnLeaseStart: anns[AnnLeaseStart]})
+			if r.Recorder != nil {
+				r.Recorder.Event(obj, "Warning", "LeaseStartReset", "Invalid lease-start, reset to now")
+			}
 		}
+	} else {
+		anns[AnnLeaseStart] = now.Format(time.RFC3339)
+		r.updateAnnotations(ctx, obj, map[string]string{AnnLeaseStart: anns[AnnLeaseStart]})
+		if r.Recorder != nil {
+			r.Recorder.Event(obj, "Normal", "LeaseStarted", "Lease started")
+		}
+		start = now
 	}
 
 	ttl, err := util.ParseFlexibleDuration(anns[AnnTTL])
 	if err != nil {
 		message := fmt.Sprintf("Invalid TTL: %v", err)
-		r.updateAnnotations(ctx, obj, map[string]string{
-			AnnStatus: message,
-		})
-
-		// Record the event
+		r.updateAnnotations(ctx, obj, map[string]string{AnnStatus: message})
 		if r.Recorder != nil {
 			r.Recorder.Event(obj, "Warning", "InvalidTTL", message)
 		}
 		return controller_runtime.Result{}, nil
 	}
+
 	expireAt := start.Add(ttl)
 
 	if now.After(expireAt) {
@@ -177,21 +178,15 @@ func (r *LeaseWatcher) Reconcile(ctx context.Context, req controller_runtime.Req
 			AnnExpireAt: expireAt.Format(time.RFC3339),
 			AnnStatus:   leaseStatus,
 		})
-
 		log.Info("Deleting object due to expired lease", "name", obj.GetName())
 		_ = r.Delete(ctx, obj)
-
-		// Record the event
 		if r.Recorder != nil {
 			r.Recorder.Event(obj, "Normal", "LeaseExpired", leaseStatus)
 		}
-
-		// Return empty result to stop further processing
 		return controller_runtime.Result{}, nil
 	}
 
 	leaseStatus := fmt.Sprintf("Lease active. Expires at %s UTC.", expireAt.Format(time.RFC3339))
-
 	r.updateAnnotations(ctx, obj, map[string]string{
 		AnnExpireAt: expireAt.Format(time.RFC3339),
 		AnnStatus:   leaseStatus,
@@ -215,10 +210,48 @@ func (r *LeaseWatcher) updateAnnotations(ctx context.Context, obj *unstructured.
 
 func (r *LeaseWatcher) SetupWithManager(mgr manager.Manager) error {
 	setupLog.Info("Setting up LeaseWatcher", "GVK", r.GVK)
+
+	// Set up tracker event listener
+	if r.Tracker != nil {
+		r.eventChan = make(chan util.NamespaceChangeEvent, 10)
+		r.Tracker.RegisterListener(r.eventChan)
+		go r.handleNamespaceEvents(mgr)
+	}
+
 	return controller_runtime.NewControllerManagedBy(mgr).
 		For(&unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": fmt.Sprintf("%s/%s", r.GVK.Group, r.GVK.Version),
 			"kind":       r.GVK.Kind,
 		}}, builder.WithPredicates(OnlyWithTTLAnnotation)).
 		Complete(r)
+}
+
+// handleNamespaceEvents listens for tracker events and triggers reconciliation for new namespaces
+func (r *LeaseWatcher) handleNamespaceEvents(mgr manager.Manager) {
+	for evt := range r.eventChan {
+		if evt.Change == util.NamespaceAdded {
+			k8sClient := mgr.GetClient()
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   r.GVK.Group,
+				Version: r.GVK.Version,
+				Kind:    r.GVK.Kind,
+			})
+			opts := &client.ListOptions{Namespace: evt.Namespace}
+			err := k8sClient.List(context.Background(), list, opts)
+			if err == nil {
+				for _, obj := range list.Items {
+					anns := obj.GetAnnotations()
+					if anns != nil {
+						if _, has := anns[AnnTTL]; has {
+							req := controller_runtime.Request{
+								NamespacedName: client.ObjectKeyFromObject(&obj),
+							}
+							go r.Reconcile(context.Background(), req)
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/pkg/controllers/lease_controller.go
+++ b/pkg/controllers/lease_controller.go
@@ -28,6 +28,10 @@ const (
 	AnnStatus     = "object-lease-controller.ullberg.us/lease-status"
 )
 
+type clientProvider interface {
+	GetClient() client.Client
+}
+
 type LeaseWatcher struct {
 	client.Client
 	GVK       schema.GroupVersionKind
@@ -227,7 +231,7 @@ func (r *LeaseWatcher) SetupWithManager(mgr manager.Manager) error {
 }
 
 // handleNamespaceEvents listens for tracker events and triggers reconciliation for new namespaces
-func (r *LeaseWatcher) handleNamespaceEvents(mgr manager.Manager) {
+func (r *LeaseWatcher) handleNamespaceEvents(mgr clientProvider) {
 	for evt := range r.eventChan {
 		if evt.Change == util.NamespaceAdded {
 			k8sClient := mgr.GetClient()

--- a/pkg/controllers/lease_controller.go
+++ b/pkg/controllers/lease_controller.go
@@ -249,7 +249,12 @@ func (r *LeaseWatcher) handleNamespaceEvents(mgr clientProvider) {
 							req := controller_runtime.Request{
 								NamespacedName: client.ObjectKeyFromObject(&obj),
 							}
-							go r.Reconcile(context.Background(), req)
+							go func(req controller_runtime.Request) {
+								ctx := context.Background()
+								if _, err := r.Reconcile(ctx, req); err != nil {
+									logger.FromContext(ctx).Error(err, "Reconcile failed", "object", req.NamespacedName)
+								}
+							}(req)
 						}
 					}
 				}

--- a/pkg/controllers/lease_controller_test.go
+++ b/pkg/controllers/lease_controller_test.go
@@ -1,22 +1,82 @@
 package controllers
 
 import (
+	"context"
+	"object-lease-controller/pkg/util"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	controller_runtime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
+// helpers
+
+type stubMgr struct{ c client.Client }
+
+func (s stubMgr) GetClient() client.Client { return s.c }
 func makeObj(anns map[string]string) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
 	u.SetAnnotations(anns)
 	return u
 }
 
+func setMeta(u *unstructured.Unstructured, gvk schema.GroupVersionKind, ns, name string) {
+	u.SetGroupVersionKind(gvk)
+	u.SetNamespace(ns)
+	u.SetName(name)
+}
+
+func newWatcher(t *testing.T, gvk schema.GroupVersionKind, objs ...client.Object) (*LeaseWatcher, client.Client, *runtime.Scheme) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	// Register object and list types for fake client Get/List
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind + "List",
+	}, &unstructured.UnstructuredList{})
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &LeaseWatcher{Client: cl, GVK: gvk}, cl, scheme
+}
+
+func waitUntil(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %v", timeout)
+}
+
+func get(t *testing.T, cl client.Client, gvk schema.GroupVersionKind, ns, name string) *unstructured.Unstructured {
+	t.Helper()
+	out := &unstructured.Unstructured{}
+	out.SetGroupVersionKind(gvk)
+	if err := cl.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, out); err != nil {
+		t.Fatalf("get error: %v", err)
+	}
+	return out
+}
+
+// existing predicate tests retained
+
 func TestLeaseRelevantAnns(t *testing.T) {
-	// TTL only
 	u := makeObj(map[string]string{
 		AnnTTL:  "1h",
 		"other": "ignore",
@@ -29,7 +89,6 @@ func TestLeaseRelevantAnns(t *testing.T) {
 		t.Errorf("leaseRelevantAnns = %v, want %v", got, want)
 	}
 
-	// TTL + lease-start both included
 	u2 := makeObj(map[string]string{
 		AnnTTL:        "30m",
 		AnnLeaseStart: "2025-01-01T00:00:00Z",
@@ -44,7 +103,6 @@ func TestLeaseRelevantAnns(t *testing.T) {
 		t.Errorf("leaseRelevantAnns = %v, want %v", got2, want2)
 	}
 
-	// No relevant annotations
 	u3 := makeObj(map[string]string{"foo": "bar"})
 	got3 := leaseRelevantAnns(u3)
 	if len(got3) != 0 {
@@ -103,7 +161,7 @@ func TestOnlyWithTTLAnnotation_Update(t *testing.T) {
 		}
 	}
 
-	// wrong-type case
+	// wrong types
 	evBad := event.UpdateEvent{
 		ObjectOld: &corev1.Pod{},
 		ObjectNew: &corev1.Pod{},
@@ -111,6 +169,7 @@ func TestOnlyWithTTLAnnotation_Update(t *testing.T) {
 	if OnlyWithTTLAnnotation.UpdateFunc(evBad) {
 		t.Errorf("UpdateFunc(wrong types) = true, want false")
 	}
+
 }
 
 func TestOnlyWithTTLAnnotation_Delete_Generic(t *testing.T) {
@@ -119,5 +178,563 @@ func TestOnlyWithTTLAnnotation_Delete_Generic(t *testing.T) {
 	}
 	if OnlyWithTTLAnnotation.GenericFunc(event.GenericEvent{}) {
 		t.Error("GenericFunc always false")
+	}
+}
+
+// TTL change updates expire-at
+func TestReconcile_UpdatesExpireAtWhenTTLChanges(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	start := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm1")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "1h",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	_, err := r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm1"}})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	got := get(t, cl, gvk, "default", "cm1")
+	exp1 := start.Add(1 * time.Hour).Format(time.RFC3339)
+	if got.GetAnnotations()[AnnExpireAt] != exp1 {
+		t.Fatalf("expire-at after TTL=1h = %q, want %q", got.GetAnnotations()[AnnExpireAt], exp1)
+	}
+
+	// change TTL to 2h
+	anns := got.GetAnnotations()
+	anns[AnnTTL] = "2h"
+	got.SetAnnotations(anns)
+	if err := cl.Update(ctx, got); err != nil {
+		t.Fatalf("update error: %v", err)
+	}
+
+	_, err = r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm1"}})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	got2 := get(t, cl, gvk, "default", "cm1")
+	exp2 := start.Add(2 * time.Hour).Format(time.RFC3339)
+	if got2.GetAnnotations()[AnnExpireAt] != exp2 {
+		t.Fatalf("expire-at after TTL=2h = %q, want %q", got2.GetAnnotations()[AnnExpireAt], exp2)
+	}
+}
+
+// Auto-start when lease-start missing
+func TestReconcile_AutoStartSetsLeaseStartAndExpire(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm2")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL: "5m",
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	before := time.Now().UTC()
+	_, err := r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm2"}})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	got := get(t, cl, gvk, "default", "cm2")
+
+	ls, err := time.Parse(time.RFC3339, got.GetAnnotations()[AnnLeaseStart])
+	if err != nil {
+		t.Fatalf("lease-start parse error: %v", err)
+	}
+	after := time.Now().UTC()
+	if ls.Before(before.Add(-2*time.Second)) || ls.After(after.Add(2*time.Second)) {
+		t.Fatalf("lease-start not within now window: %v vs [%v,%v]", ls, before, after)
+	}
+	exp := ls.Add(5 * time.Minute).Format(time.RFC3339)
+	if got.GetAnnotations()[AnnExpireAt] != exp {
+		t.Fatalf("expire-at = %q, want %q", got.GetAnnotations()[AnnExpireAt], exp)
+	}
+}
+
+// Invalid lease-start resets and updates expire
+func TestReconcile_InvalidLeaseStartResetsAndUpdatesExpire(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm3")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "10m",
+		AnnLeaseStart: "not-a-time",
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	_, err := r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm3"}})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	got := get(t, cl, gvk, "default", "cm3")
+	ls, err := time.Parse(time.RFC3339, got.GetAnnotations()[AnnLeaseStart])
+	if err != nil {
+		t.Fatalf("lease-start not reset to RFC3339: %v", err)
+	}
+	exp := ls.Add(10 * time.Minute).Format(time.RFC3339)
+	if got.GetAnnotations()[AnnExpireAt] != exp {
+		t.Fatalf("expire-at = %q, want %q", got.GetAnnotations()[AnnExpireAt], exp)
+	}
+}
+
+// Invalid TTL writes status, no expire, no delete
+func TestReconcile_InvalidTTL_StatusOnly_NoExpire_NoDelete(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm4")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL: "totally-wrong",
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	_, err := r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm4"}})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	got := get(t, cl, gvk, "default", "cm4")
+	anns := got.GetAnnotations()
+	if anns[AnnExpireAt] != "" {
+		t.Fatalf("expire-at should be empty, got %q", anns[AnnExpireAt])
+	}
+	if !strings.Contains(anns[AnnStatus], "Invalid TTL") {
+		t.Fatalf("lease-status should mention Invalid TTL, got %q", anns[AnnStatus])
+	}
+}
+
+// TTL removal clears lease annotations
+func TestReconcile_RemoveTTL_CleansLeaseAnnotations(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm5")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "1h",
+		AnnLeaseStart: time.Now().UTC().Format(time.RFC3339),
+		AnnExpireAt:   time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339),
+		AnnStatus:     "ok",
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	// remove TTL
+	cur := get(t, cl, gvk, "default", "cm5")
+	anns := cur.GetAnnotations()
+	delete(anns, AnnTTL)
+	cur.SetAnnotations(anns)
+	if err := cl.Update(ctx, cur); err != nil {
+		t.Fatalf("update error: %v", err)
+	}
+
+	_, err := r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm5"}})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	got := get(t, cl, gvk, "default", "cm5")
+	out := got.GetAnnotations()
+	if _, ok := out[AnnLeaseStart]; ok {
+		t.Fatalf("lease-start should be cleaned")
+	}
+	if _, ok := out[AnnExpireAt]; ok {
+		t.Fatalf("expire-at should be cleaned")
+	}
+	if _, ok := out[AnnStatus]; ok {
+		t.Fatalf("lease-status should be cleaned")
+	}
+}
+
+// Extend by deleting lease-start
+func TestReconcile_ExtendByDeletingLeaseStart(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	start := time.Now().UTC().Add(-1 * time.Minute).Truncate(time.Second)
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm6")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "10m",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	_, _ = r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm6"}})
+	got := get(t, cl, gvk, "default", "cm6")
+	oldExp, _ := time.Parse(time.RFC3339, got.GetAnnotations()[AnnExpireAt])
+
+	anns := got.GetAnnotations()
+	delete(anns, AnnLeaseStart)
+	got.SetAnnotations(anns)
+	if err := cl.Update(ctx, got); err != nil {
+		t.Fatalf("update error: %v", err)
+	}
+
+	_, _ = r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm6"}})
+	got2 := get(t, cl, gvk, "default", "cm6")
+	newExp, _ := time.Parse(time.RFC3339, got2.GetAnnotations()[AnnExpireAt])
+	if !newExp.After(oldExp) {
+		t.Fatalf("new expire-at %v should be after old %v", newExp, oldExp)
+	}
+}
+
+// Expired deletes the object
+func TestReconcile_ExpiredDeletesObject(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm7")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "1s",
+		AnnLeaseStart: time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339),
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	_, _ = r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm7"}})
+
+	out := &unstructured.Unstructured{}
+	out.SetGroupVersionKind(gvk)
+	err := cl.Get(ctx, types.NamespacedName{Namespace: "default", Name: "cm7"}, out)
+	if err == nil || !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound after delete, got %v", err)
+	}
+}
+
+// Idempotency: no change on repeated reconcile
+func TestReconcile_Idempotent_NoChange(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	start := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Second)
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm8")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "1h",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	_, _ = r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm8"}})
+	a1 := get(t, cl, gvk, "default", "cm8").GetAnnotations()
+
+	time.Sleep(10 * time.Millisecond) // small delay
+	_, _ = r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm8"}})
+	a2 := get(t, cl, gvk, "default", "cm8").GetAnnotations()
+
+	if !reflect.DeepEqual(a1, a2) {
+		t.Fatalf("annotations changed between reconciles: %v vs %v", a1, a2)
+	}
+}
+
+// RequeueAfter ≈ expire-at - now
+func TestReconcile_RequeueAfterApproxTTL(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	start := time.Now().UTC().Add(10 * time.Second).Truncate(time.Second)
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "default", "cm9")
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "1h",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	before := time.Now().UTC()
+	res, err := r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "cm9"}})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	got := get(t, cl, gvk, "default", "cm9")
+	exp, _ := time.Parse(time.RFC3339, got.GetAnnotations()[AnnExpireAt])
+
+	// expected ≈ exp - now
+	elapsed := time.Since(before)
+	expected := time.Until(exp)
+
+	if res.RequeueAfter <= 0 {
+		t.Fatalf("RequeueAfter should be positive, got %v", res.RequeueAfter)
+	}
+	// allow small drift
+	diff := res.RequeueAfter - expected
+	if diff < -3*time.Second || diff > (elapsed+3*time.Second) {
+		t.Fatalf("RequeueAfter %v not close to expected %v (diff %v)", res.RequeueAfter, expected, diff)
+	}
+}
+
+// NotFound returns no error
+func TestReconcile_NotFound_NoError(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	r, _, _ := newWatcher(t, gvk /* no objects */)
+
+	_, err := r.Reconcile(ctx, controller_runtime.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "does-not-exist"}})
+	if err != nil {
+		t.Fatalf("expected nil error on not found, got %v", err)
+	}
+}
+
+// Predicate guardrail: unrelated annotation change does not trigger
+func TestPredicate_UnrelatedAnnotationChangeDoesNotTrigger(t *testing.T) {
+	oldObj := makeObj(map[string]string{AnnTTL: "1h"})
+	newObj := makeObj(map[string]string{AnnTTL: "1h", "unrelated": "x"})
+	ev := event.UpdateEvent{ObjectOld: oldObj, ObjectNew: newObj}
+	if OnlyWithTTLAnnotation.UpdateFunc(ev) {
+		t.Fatalf("unrelated annotation change should not trigger")
+	}
+}
+
+// helper: like newWatcher but with a tracker
+func newWatcherWithTracker(t *testing.T, gvk schema.GroupVersionKind, tr *util.NamespaceTracker, objs ...client.Object) (*LeaseWatcher, client.Client) {
+	t.Helper()
+	r, cl, _ := newWatcher(t, gvk, objs...)
+	r.Tracker = tr
+	return r, cl
+}
+
+func TestReconcile_SkipsUntrackedNamespace(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	// object lives in ns-a
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "ns-a", "cm-ns-a")
+	start := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Second)
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "1h",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	// tracker only allows ns-b
+	tr := util.NewNamespaceTracker()
+	tr.AddNamespace("ns-b")
+
+	r, cl := newWatcherWithTracker(t, gvk, tr, obj)
+
+	// reconcile for ns-a should be skipped, so expire-at must remain empty
+	_, err := r.Reconcile(ctx, controller_runtime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns-a", Name: "cm-ns-a"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	got := get(t, cl, gvk, "ns-a", "cm-ns-a")
+	if v := got.GetAnnotations()[AnnExpireAt]; v != "" {
+		t.Fatalf("expire-at set for untracked namespace: %q", v)
+	}
+}
+
+func TestReconcile_ProcessesTrackedNamespace(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	// object lives in ns-b
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "ns-b", "cm-ns-b")
+	start := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Second)
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "45m",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	tr := util.NewNamespaceTracker()
+	tr.AddNamespace("ns-b")
+
+	r, cl := newWatcherWithTracker(t, gvk, tr, obj)
+
+	_, err := r.Reconcile(ctx, controller_runtime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns-b", Name: "cm-ns-b"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	got := get(t, cl, gvk, "ns-b", "cm-ns-b")
+	wantExp := start.Add(45 * time.Minute).Format(time.RFC3339)
+	if got.GetAnnotations()[AnnExpireAt] != wantExp {
+		t.Fatalf("expire-at = %q, want %q", got.GetAnnotations()[AnnExpireAt], wantExp)
+	}
+}
+
+func TestReconcile_NoTrackerProcessesAllNamespaces(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	// object in any namespace should be processed if tracker is nil
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "random-ns", "cm-any")
+	start := time.Now().UTC().Add(15 * time.Minute).Truncate(time.Second)
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "30m",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	r, cl, _ := newWatcher(t, gvk, obj) // Tracker nil
+
+	_, err := r.Reconcile(ctx, controller_runtime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "random-ns", Name: "cm-any"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	got := get(t, cl, gvk, "random-ns", "cm-any")
+	wantExp := start.Add(30 * time.Minute).Format(time.RFC3339)
+	if got.GetAnnotations()[AnnExpireAt] != wantExp {
+		t.Fatalf("expire-at = %q, want %q", got.GetAnnotations()[AnnExpireAt], wantExp)
+	}
+}
+
+func TestReconcile_NamespaceBecomesTrackedLater(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "late-ns", "cm-late")
+	start := time.Now().UTC().Add(20 * time.Minute).Truncate(time.Second)
+	obj.SetAnnotations(map[string]string{
+		AnnTTL:        "40m",
+		AnnLeaseStart: start.Format(time.RFC3339),
+	})
+
+	tr := util.NewNamespaceTracker() // initially empty
+	r, cl := newWatcherWithTracker(t, gvk, tr, obj)
+
+	// first reconcile should skip
+	_, err := r.Reconcile(ctx, controller_runtime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "late-ns", Name: "cm-late"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	if v := get(t, cl, gvk, "late-ns", "cm-late").GetAnnotations()[AnnExpireAt]; v != "" {
+		t.Fatalf("expire-at should be empty before namespace is tracked, got %q", v)
+	}
+
+	// now track the namespace and reconcile again
+	tr.AddNamespace("late-ns")
+	_, err = r.Reconcile(ctx, controller_runtime.Request{
+		NamespacedName: types.NamespacedName{Namespace: "late-ns", Name: "cm-late"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	wantExp := start.Add(40 * time.Minute).Format(time.RFC3339)
+	if v := get(t, cl, gvk, "late-ns", "cm-late").GetAnnotations()[AnnExpireAt]; v != wantExp {
+		t.Fatalf("expire-at = %q, want %q", v, wantExp)
+	}
+}
+
+func TestHandleNamespaceEvents_ProcessesAddedNamespace(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	withTTL := &unstructured.Unstructured{}
+	setMeta(withTTL, gvk, "ns-a", "cm-ttl")
+	withTTL.SetAnnotations(map[string]string{AnnTTL: "30m"})
+
+	withoutTTL := &unstructured.Unstructured{}
+	setMeta(withoutTTL, gvk, "ns-a", "cm-no-ttl")
+
+	nsB := &unstructured.Unstructured{}
+	setMeta(nsB, gvk, "ns-b", "cm-b")
+	nsB.SetAnnotations(map[string]string{AnnTTL: "15m"})
+
+	r, cl, _ := newWatcher(t, gvk, withTTL, withoutTTL, nsB)
+
+	r.eventChan = make(chan util.NamespaceChangeEvent, 1)
+	go r.handleNamespaceEvents(stubMgr{c: cl})
+
+	r.eventChan <- util.NamespaceChangeEvent{Namespace: "ns-a", Change: util.NamespaceAdded}
+	close(r.eventChan)
+
+	waitUntil(t, 2*time.Second, func() bool {
+		obj := get(t, cl, gvk, "ns-a", "cm-ttl")
+		ls := obj.GetAnnotations()[AnnLeaseStart]
+		ea := obj.GetAnnotations()[AnnExpireAt]
+		if ls == "" || ea == "" {
+			return false
+		}
+		start, err1 := time.Parse(time.RFC3339, ls)
+		exp, err2 := time.Parse(time.RFC3339, ea)
+		return err1 == nil && err2 == nil && exp.Equal(start.Add(30*time.Minute))
+	})
+
+	if v := get(t, cl, gvk, "ns-a", "cm-no-ttl").GetAnnotations()[AnnExpireAt]; v != "" {
+		t.Fatalf("unexpected expire-at for object without TTL: %q", v)
+	}
+	if v := get(t, cl, gvk, "ns-b", "cm-b").GetAnnotations()[AnnExpireAt]; v != "" {
+		t.Fatalf("ns-b object should not be processed by ns-a event, got %q", v)
+	}
+}
+
+func TestHandleNamespaceEvents_IgnoresNonAddedEvents(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	obj := &unstructured.Unstructured{}
+	setMeta(obj, gvk, "ns-x", "cm-x")
+	obj.SetAnnotations(map[string]string{AnnTTL: "10m"})
+
+	r, cl, _ := newWatcher(t, gvk, obj)
+
+	r.eventChan = make(chan util.NamespaceChangeEvent, 1)
+	go r.handleNamespaceEvents(stubMgr{c: cl})
+
+	r.eventChan <- util.NamespaceChangeEvent{Namespace: "ns-x", Change: util.NamespaceRemoved}
+	close(r.eventChan)
+
+	time.Sleep(50 * time.Millisecond)
+	if v := get(t, cl, gvk, "ns-x", "cm-x").GetAnnotations()[AnnExpireAt]; v != "" {
+		t.Fatalf("non-Added event should not process objects, got expire-at=%q", v)
+	}
+}
+
+func TestHandleNamespaceEvents_ProcessesMultipleObjectsInAddedNamespace(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+
+	a1 := &unstructured.Unstructured{}
+	setMeta(a1, gvk, "ns-y", "a1")
+	a1.SetAnnotations(map[string]string{AnnTTL: "5m"})
+
+	a2 := &unstructured.Unstructured{}
+	setMeta(a2, gvk, "ns-y", "a2")
+	a2.SetAnnotations(map[string]string{AnnTTL: "1h"})
+
+	a3 := &unstructured.Unstructured{} // no TTL, should be ignored
+	setMeta(a3, gvk, "ns-y", "a3")
+	a3.SetAnnotations(map[string]string{})
+
+	r, cl, _ := newWatcher(t, gvk, a1, a2, a3)
+	r.eventChan = make(chan util.NamespaceChangeEvent, 1)
+	go r.handleNamespaceEvents(stubMgr{c: cl})
+
+	r.eventChan <- util.NamespaceChangeEvent{Namespace: "ns-y", Change: util.NamespaceAdded}
+	close(r.eventChan)
+
+	waitUntil(t, 2*time.Second, func() bool {
+		g1 := get(t, cl, gvk, "ns-y", "a1").GetAnnotations()[AnnExpireAt]
+		g2 := get(t, cl, gvk, "ns-y", "a2").GetAnnotations()[AnnExpireAt]
+		return g1 != "" && g2 != ""
+	})
+	if v := get(t, cl, gvk, "ns-y", "a3").GetAnnotations()[AnnExpireAt]; v != "" {
+		t.Fatalf("object without TTL should be ignored, got expire-at=%q", v)
 	}
 }

--- a/pkg/controllers/namespace_controller.go
+++ b/pkg/controllers/namespace_controller.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"context"
+
+	"object-lease-controller/pkg/util"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logger "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type NamespaceReconciler struct {
+	client.Client
+	Log        logr.Logger
+	LabelKey   string
+	LabelValue string
+	Tracker    *util.NamespaceTracker
+	Recorder   record.EventRecorder
+}
+
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return builder.ControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		WithEventFilter(predicate.Or(
+			predicate.LabelChangedPredicate{},
+			predicate.GenerationChangedPredicate{},
+		)).
+		Complete(r)
+}
+
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var ns corev1.Namespace
+	log := logger.FromContext(ctx).WithValues("namespace", req.Name)
+
+	if err := r.Get(ctx, req.NamespacedName, &ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(2).Info("Namespace not found, not tracking", "namespace", req.Name)
+			r.Tracker.RemoveNamespace(req.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if ns.Labels[r.LabelKey] == r.LabelValue {
+		log.Info("Namespace label matches, tracking")
+		r.Tracker.AddNamespace(req.Name)
+	} else {
+		if _, exists := ns.Labels[r.LabelKey]; exists {
+			log.V(2).Info("Namespace label exists but does not match, not tracking", "labelKey", r.LabelKey, "labelValue", r.LabelValue)
+		} else {
+			log.V(2).Info("Namespace label does not exist, not tracking", "labelKey", r.LabelKey)
+		}
+		r.Tracker.RemoveNamespace(req.Name)
+	}
+	return ctrl.Result{}, nil
+}

--- a/pkg/controllers/namespace_controller_test.go
+++ b/pkg/controllers/namespace_controller_test.go
@@ -1,0 +1,210 @@
+// pkg/controllers/namespace_controller_test.go
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"object-lease-controller/pkg/util"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func newReq(name string) ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}
+}
+
+// erroringClient wraps a client and forces Get to return an error
+type erroringClient struct {
+	client crclient.Client
+	err    error
+}
+
+func (e *erroringClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return e.client.GroupVersionKindFor(obj)
+}
+func (e *erroringClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return e.client.IsObjectNamespaced(obj)
+}
+func (e *erroringClient) Get(ctx context.Context, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+	return e.err
+}
+func (e *erroringClient) Create(ctx context.Context, obj crclient.Object, opts ...crclient.CreateOption) error {
+	return e.client.Create(ctx, obj, opts...)
+}
+func (e *erroringClient) Delete(ctx context.Context, obj crclient.Object, opts ...crclient.DeleteOption) error {
+	return e.client.Delete(ctx, obj, opts...)
+}
+func (e *erroringClient) Update(ctx context.Context, obj crclient.Object, opts ...crclient.UpdateOption) error {
+	return e.client.Update(ctx, obj, opts...)
+}
+func (e *erroringClient) Patch(ctx context.Context, obj crclient.Object, patch crclient.Patch, opts ...crclient.PatchOption) error {
+	return e.client.Patch(ctx, obj, patch, opts...)
+}
+func (e *erroringClient) DeleteAllOf(ctx context.Context, obj crclient.Object, opts ...crclient.DeleteAllOfOption) error {
+	return e.client.DeleteAllOf(ctx, obj, opts...)
+}
+func (e *erroringClient) List(ctx context.Context, list crclient.ObjectList, opts ...crclient.ListOption) error {
+	return e.client.List(ctx, list, opts...)
+}
+func (e *erroringClient) Status() crclient.SubResourceWriter { return e.client.Status() }
+func (e *erroringClient) SubResource(s string) crclient.SubResourceClient {
+	return e.client.SubResource(s)
+}
+func (e *erroringClient) Scheme() *runtime.Scheme     { return e.client.Scheme() }
+func (e *erroringClient) RESTMapper() meta.RESTMapper { return e.client.RESTMapper() }
+
+func TestReconcile_AddsNamespaceOnMatchingLabel(t *testing.T) {
+	scheme := newScheme(t)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "optin",
+			Labels: map[string]string{"watch/enabled": "true"},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	tracker := util.NewNamespaceTracker()
+
+	r := &NamespaceReconciler{
+		Client:     cl,
+		LabelKey:   "watch/enabled",
+		LabelValue: "true",
+		Tracker:    tracker,
+	}
+
+	_, err := r.Reconcile(context.Background(), newReq("optin"))
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	if !tracker.TrackingNamespace("optin") {
+		t.Fatalf("expected tracker to contain namespace optin")
+	}
+}
+
+func TestReconcile_RemovesNamespaceOnMismatchedLabel(t *testing.T) {
+	scheme := newScheme(t)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "mismatch",
+			Labels: map[string]string{"watch/enabled": "false"},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	tracker := util.NewNamespaceTracker()
+	tracker.AddNamespace("mismatch")
+
+	r := &NamespaceReconciler{
+		Client:     cl,
+		LabelKey:   "watch/enabled",
+		LabelValue: "true",
+		Tracker:    tracker,
+	}
+
+	_, err := r.Reconcile(context.Background(), newReq("mismatch"))
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	if tracker.TrackingNamespace("mismatch") {
+		t.Fatalf("expected tracker to not contain namespace mismatch")
+	}
+}
+
+func TestReconcile_RemoveWhenLabelMissing(t *testing.T) {
+	scheme := newScheme(t)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nolabel",
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	tracker := util.NewNamespaceTracker()
+	tracker.AddNamespace("nolabel") // ensure it stays tracked
+
+	r := &NamespaceReconciler{
+		Client:     cl,
+		LabelKey:   "watch/enabled",
+		LabelValue: "true",
+		Tracker:    tracker,
+	}
+
+	_, err := r.Reconcile(context.Background(), newReq("nolabel"))
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	if tracker.TrackingNamespace("nolabel") {
+		t.Fatalf("expected tracker to not contain namespace nolabel")
+	}
+}
+
+func TestReconcile_NotFoundRemovesTracking(t *testing.T) {
+	scheme := newScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build() // no objects
+
+	tracker := util.NewNamespaceTracker()
+	tracker.AddNamespace("ghost")
+
+	r := &NamespaceReconciler{
+		Client:     cl,
+		LabelKey:   "watch/enabled",
+		LabelValue: "true",
+		Tracker:    tracker,
+	}
+
+	_, err := r.Reconcile(context.Background(), newReq("ghost"))
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	if tracker.TrackingNamespace("ghost") {
+		t.Fatalf("expected tracker to remove namespace ghost after NotFound")
+	}
+}
+
+func TestReconcile_ClientErrorBubblesUp(t *testing.T) {
+	scheme := newScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	cl := &erroringClient{client: base, err: errors.New("boom")}
+
+	tracker := util.NewNamespaceTracker()
+	tracker.AddNamespace("ns")
+
+	r := &NamespaceReconciler{
+		Client:     cl,
+		LabelKey:   "watch/enabled",
+		LabelValue: "true",
+		Tracker:    tracker,
+	}
+
+	_, err := r.Reconcile(context.Background(), newReq("ns"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !tracker.TrackingNamespace("ns") {
+		t.Fatalf("expected tracker to still contain namespace ns on error")
+	}
+}

--- a/pkg/util/tracker.go
+++ b/pkg/util/tracker.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"log"
 	"sync"
 )
 
@@ -83,7 +84,7 @@ func (t *NamespaceTracker) notifyListeners(event NamespaceChangeEvent) {
 		select {
 		case ch <- event:
 		default:
-			// skip if channel is full
+			log.Printf("NamespaceTracker: dropped event for namespace %q (change: %v) because listener channel is full", event.Namespace, event.Change)
 		}
 	}
 }

--- a/pkg/util/tracker.go
+++ b/pkg/util/tracker.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"sync"
+)
+
+// NamespaceChangeType represents the type of change in the tracker
+type NamespaceChangeType int
+
+const (
+	NamespaceAdded NamespaceChangeType = iota
+	NamespaceRemoved
+)
+
+// NamespaceChangeEvent represents a change event for namespaces
+type NamespaceChangeEvent struct {
+	Namespace string
+	Change    NamespaceChangeType
+}
+
+// NamespaceTracker tracks namespaces and notifies listeners on changes
+type NamespaceTracker struct {
+	mu         sync.RWMutex
+	namespaces map[string]struct{}
+	listeners  []chan NamespaceChangeEvent
+}
+
+func NewNamespaceTracker() *NamespaceTracker {
+	return &NamespaceTracker{
+		namespaces: make(map[string]struct{}),
+		listeners:  make([]chan NamespaceChangeEvent, 0),
+	}
+}
+
+// AddNamespace adds a namespace and notifies listeners
+func (t *NamespaceTracker) AddNamespace(ns string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, exists := t.namespaces[ns]; !exists {
+		t.namespaces[ns] = struct{}{}
+		t.notifyListeners(NamespaceChangeEvent{Namespace: ns, Change: NamespaceAdded})
+	}
+}
+
+// RemoveNamespace removes a namespace and notifies listeners
+func (t *NamespaceTracker) RemoveNamespace(ns string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, exists := t.namespaces[ns]; exists {
+		delete(t.namespaces, ns)
+		t.notifyListeners(NamespaceChangeEvent{Namespace: ns, Change: NamespaceRemoved})
+	}
+}
+
+// ListNamespaces returns a slice of tracked namespaces
+func (t *NamespaceTracker) ListNamespaces() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	ns := make([]string, 0, len(t.namespaces))
+	for k := range t.namespaces {
+		ns = append(ns, k)
+	}
+	return ns
+}
+
+// TrackingNamespace returns true if the namespace is being tracked
+func (t *NamespaceTracker) TrackingNamespace(ns string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, exists := t.namespaces[ns]
+	return exists
+}
+
+// RegisterListener registers a channel to receive change events
+func (t *NamespaceTracker) RegisterListener(ch chan NamespaceChangeEvent) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.listeners = append(t.listeners, ch)
+}
+
+func (t *NamespaceTracker) notifyListeners(event NamespaceChangeEvent) {
+	for _, ch := range t.listeners {
+		select {
+		case ch <- event:
+		default:
+			// skip if channel is full
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces namespace opt-in functionality for the object lease controller, allowing the controller to selectively manage objects based on namespace labels. The implementation adds a namespace tracker to monitor which namespaces should be included in lease management.

Key changes:

    Adds namespace-based filtering with opt-in label support
    Replaces extended-at annotation with lease-start for more precise lease timing control
    Refactors the lease controller package structure and improves test coverage


<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
Signed-off-by: Magnus Ullberg <magnus@ullberg.us>