### PR TITLE
optimize caching

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,14 @@ import (
 	"object-lease-controller/pkg/util"
 )
 
+// Lease annotation keys
+const (
+	AnnTTL        = "object-lease-controller.ullberg.us/ttl"
+	AnnLeaseStart = "object-lease-controller.ullberg.us/lease-start" // RFC3339 UTC
+	AnnExpireAt   = "object-lease-controller.ullberg.us/expire-at"
+	AnnStatus     = "object-lease-controller.ullberg.us/lease-status"
+)
+
 var (
 	setupLog = ctrl.Log.WithName("setup")
 )
@@ -134,7 +142,9 @@ func main() {
 		Metrics:                       metricsServerOptions,
 		HealthProbeBindAddress:        probeAddr,
 		Cache: cache.Options{
-			DefaultTransform: cache.TransformStripManagedFields(),
+			DefaultTransform: util.MinimalObjectTransform(
+				AnnTTL, AnnLeaseStart, AnnExpireAt, AnnStatus,
+			),
 		},
 	}
 

--- a/pkg/util/object_filter.go
+++ b/pkg/util/object_filter.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kcache "k8s.io/client-go/tools/cache"
+	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func MinimalObjectTransform(keepKeys ...string) kcache.TransformFunc {
+	keep := make(map[string]struct{}, len(keepKeys))
+	for _, k := range keepKeys {
+		keep[k] = struct{}{}
+	}
+	stripMF := crcache.TransformStripManagedFields()
+
+	return func(obj interface{}) (interface{}, error) {
+		if trimmed, err := stripMF(obj); err == nil {
+			obj = trimmed
+		}
+		switch o := obj.(type) {
+		case *unstructured.Unstructured:
+			return stripU(o, keep), nil
+		case *unstructured.UnstructuredList:
+			for i := range o.Items {
+				u := stripU(&o.Items[i], keep)
+				o.Items[i] = *u
+			}
+			return o, nil
+		default:
+			return obj, nil
+		}
+	}
+}
+
+func stripU(in *unstructured.Unstructured, keep map[string]struct{}) *unstructured.Unstructured {
+	out := &unstructured.Unstructured{}
+	out.SetAPIVersion(in.GetAPIVersion())
+	out.SetKind(in.GetKind())
+	out.SetName(in.GetName())
+	out.SetNamespace(in.GetNamespace())
+	out.SetUID(in.GetUID())
+	out.SetResourceVersion(in.GetResourceVersion())
+	if ts := in.GetDeletionTimestamp(); ts != nil {
+		out.SetDeletionTimestamp(ts)
+	}
+	if anns := in.GetAnnotations(); len(anns) > 0 {
+		filtered := make(map[string]string, 4)
+		for k, v := range anns {
+			if _, ok := keep[k]; ok {
+				filtered[k] = v
+			}
+		}
+		if len(filtered) > 0 {
+			out.SetAnnotations(filtered)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Refactoring (no functional changes, no API changes)
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently, the controller cache stores full Kubernetes objects, including all annotations and managed fields, which can lead to excessive memory usage. Annotation keys for lease management are hardcoded and scattered.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduces a new `MinimalObjectTransform` utility to filter out unnecessary fields and annotations when reading objects, reducing memory usage.
- Refactors lease annotation keys into a dedicated struct (`Annotations`) for better maintainability and testability.
- Updates controller logic and tests to use the new annotation struct and transformation utility.
- Predicate logic for triggering reconciles is now annotation-driven and instance-specific.
- Improves test coverage and clarity by using the new annotation struct in all relevant places.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

This change is internal and should not affect external APIs or existing deployments. It improves performance and maintainability.