### PR TITLE
update dependencies for plugin

### DIFF
--- a/object-lease-console-plugin/package.json
+++ b/object-lease-console-plugin/package.json
@@ -15,26 +15,26 @@
   },
   "dependencies": {
     "@openshift-console/dynamic-plugin-sdk": "^4.19.0",
-  "@patternfly/react-core": "^4.214.7",
-  "@patternfly/react-icons": "^4.93.6",
-  "react": "^17.0.2",
-  "react-dom": "^17.0.2",
-  "react-router-dom": "^5.3.4",
-  "react-i18next": "^11.12.0",
-  "i18next": "^21.10.0"
+    "@patternfly/react-core": "^6.3.1",
+    "@patternfly/react-icons": "^6.3.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-router-dom": "^5.3.3",
+    "react-i18next": "^11.12.0",
+    "i18next": "^25.3.4"
   },
   "devDependencies": {
     "@openshift-console/dynamic-plugin-sdk-webpack": "^4.19.0",
-  "@types/react": "17",
-  "@types/react-dom": "17",
-  "@types/react-router-dom": "5",
-  "css-loader": "^6.10.0",
-  "copy-webpack-plugin": "^12.0.2",
-  "style-loader": "^3.3.4",
-    "ts-loader": "^9.4.4",
-    "typescript": "^5.6.2",
-    "webpack": "^5.93.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "@types/react": "17.0.1",
+    "@types/react-dom": "17.0.1",
+    "@types/react-router-dom": "5.3.3",
+    "css-loader": "^7.1.2",
+    "copy-webpack-plugin": "^13.0.0",
+    "style-loader": "^4.0.0",
+    "ts-loader": "^9.5.2",
+    "typescript": "^5.9.2",
+    "webpack": "^5.101.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.2"
   }
 }

--- a/object-lease-console-plugin/src/components/LeasesPage.tsx
+++ b/object-lease-console-plugin/src/components/LeasesPage.tsx
@@ -133,7 +133,7 @@ const LeasesPage = () => {
   }, [leaseControllers, lcLoaded, lcError]);
 
   return (
-    <PageSection variant="light">
+    <PageSection variant="default" className="pf-v5-u-m-md pf-v5-u-p-md">
       <Title headingLevel="h1">Objects with TTL annotation</Title>
       {!loaded && !loadError && <div>Loading…</div>}
       {loadError && <div>Error loading: {String(loadError?.message || loadError)}</div>}


### PR DESCRIPTION
# Feature Request

**Describe the Feature Request**

Add small, consistent spacing around the console plugin page and align with PatternFly v6 type expectations. Include broad dependency updates to modernize build/tooling and address deprecations.

This also resolves a TS error caused by an invalid PageSection variant.

**Describe Preferred Solution**

- Apply PF utility classes on the outer PageSection: pf-v5-u-m-md pf-v5-u-p-md for margin/padding.
- Change PageSection variant from "light" to "default" (valid in current PF types).

**Describe Alternatives**

- Wrap content in a layout/container with custom CSS.
- Use only padding (no margin) or adjust spacing tokens (sm/lg).
- Introduce a shared layout wrapper component.

**Related Code**

- LeasesPage.tsx
  - variant="default", add className="pf-v5-u-m-md pf-v5-u-p-md"
- package.json
  - Key updates:
    - @patternfly/react-core: ^6.3.1
    - @patternfly/react-icons: ^6.3.1
    - @openshift-console/dynamic-plugin-sdk(-webpack): ^4.19.0
    - i18next: ^25.3.4
    - react/react-dom: ^17.0.1
    - css-loader ^7, style-loader ^4
    - webpack ^5.101.0, webpack-cli ^6.0.1, webpack-dev-server ^5.2.2
    - ts-loader ^9.5.2, typescript ^5.9.2
    - @types/react, @types/react-dom, @types/react-router-dom pinned to 17/5

- Commit: dbdf75c

**Additional Context**

- Fixed TS2322: "light" not assignable for PageSection variant under current PF types.
- Built and tagged plugin image: ghcr.io/ullbergm/object-lease-console-plugin:v0.2.1.
- Pushed image successfully.

**If the feature request is approved, would you be willing to submit a PR?**
_(Help can be provided if you need assistance submitting a PR)_

- [x] Yes
- [ ] No