### PR TITLE
fix(renovate): group OpenShift Console SDK dependencies and block React updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -106,6 +106,21 @@
             "semanticCommitType": "fix",
             "semanticCommitScope": "npm",
             "addLabels": ["renovate/npm"]
+        },
+        {
+            "matchManagers": ["npm"],
+            "matchPackagePatterns": ["^@openshift-console/"],
+            "matchPaths": ["object-lease-console-plugin/**"],
+            "groupName": "OpenShift Console SDK",
+            "groupSlug": "openshift-console-sdk",
+            "addLabels": ["renovate/npm", "renovate/openshift-sdk"]
+        },
+        {
+            "matchManagers": ["npm"],
+            "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+            "matchPaths": ["object-lease-console-plugin/**"],
+            "enabled": false,
+            "addLabels": ["renovate/npm", "renovate/blocked"]
         }
     ]
 }


### PR DESCRIPTION
## Changes

This PR updates the Renovate configuration to better handle OpenShift Console SDK dependencies:

### OpenShift Console SDK Grouping
- Groups all `@openshift-console/*` packages together using a pattern matcher
- Ensures `@openshift-console/dynamic-plugin-sdk` and `@openshift-console/dynamic-plugin-sdk-webpack` update together in a single PR
- Both packages will stay synchronized and only update when there's a new version available

### React Version Pinning
- Disables Renovate updates for `react`, `react-dom`, `@types/react`, and `@types/react-dom`
- The OpenShift Console plugin requires specific React versions for compatibility
- These versions should only be updated manually when the OpenShift Console SDK updates its peer dependency requirements

## Benefits

- Prevents version mismatches between the main SDK and webpack plugin
- Reduces PR noise by grouping related updates
- Ensures React compatibility with the OpenShift Console plugin requirements