### PR TITLE
ci(renovate): group controller-runtime with the kubernetes monorepo

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,20 @@
             ],
         },
         {
+            // controller-runtime is released in lockstep with the Kubernetes
+            // libraries and does not compile against a newer k8s.io/* minor.
+            // Keep them in one PR so neither half can block the other.
+            matchDatasources: [
+                'go',
+            ],
+            matchPackageNames: [
+                'k8s.io/**',
+                'sigs.k8s.io/controller-runtime',
+            ],
+            groupName: 'kubernetes monorepo',
+            groupSlug: 'kubernetes-monorepo',
+        },
+        {
             matchDatasources: [
                 'docker',
             ],


### PR DESCRIPTION
`k8s.io/*` and `sigs.k8s.io/controller-runtime` are released in lockstep, but Renovate was updating them in separate PRs. That deadlocks both sides: #86 (k8s v0.36.3) fails to compile against controller-runtime v0.23.1, and a lone controller-runtime bump would have the mirror-image problem.

Grouping them into the existing `kubernetes-monorepo` branch means the pair always moves together.

Validated with `renovate-config-validator`.