### PR TITLE
ci(lint): pin golangci-lint to v2.12.2 in both workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,3 +21,5 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        with:
+          version: v2.12.2

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,9 +25,10 @@ jobs:
           go-version-file: go.mod
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           install-only: true
+          version: v2.12.2
 
       - name: Check commits
         run: pre-commit run --hook-stage manual --all-files


### PR DESCRIPTION
## Why

`lint.yml` and `pr-check.yml` both installed golangci-lint without a `version`, so CI tracked whatever was latest at run time. A new linter release could — and did — turn every branch red with no code change: the `goconst` wave fixed in #89.

## What

- `version: v2.12.2` in both workflows (the version currently resolved as latest, and the one #89 was verified against).
- Pins `golangci/golangci-lint-action` to its digest in `pr-check.yml`. It was the only bare `@v9` among otherwise digest-pinned actions.

Renovate's github-actions manager extracts the `version` input of `golangci-lint-action` and tracks `golangci/golangci-lint`, so upgrades now arrive as a reviewable PR rather than a surprise failure. No Renovate config change needed.

## Verification

`golangci-lint run` at v2.12.2 → 0 issues.